### PR TITLE
更新漏れがあったので修正

### DIFF
--- a/src/Hinata/PenlightColorList.tsx
+++ b/src/Hinata/PenlightColorList.tsx
@@ -32,7 +32,7 @@ function PenlightColorList({setPage}:{setPage:React.Dispatch<React.SetStateActio
           <br />
           <button className='btn1' onClick={()=>onPlay({filters:[],category:"全メンバー + 卒業メンバー"})}>全メンバー + 卒業メンバー<br/>(36名)</button>
           <br />
-          <button className='btn1' onClick={()=>onPlay({filters:[{key:"term",property:4},{key:"graduated",property:false}],category:"「４期生ライブ」メンバー"})}>「４期生ライブ」メンバー<br/>(11名)</button>
+          <button className='btn1' onClick={()=>onPlay({filters:[{key:"hiragana",property:true}],category:"12thひなた坂46LIVEメンバー"})}>12thひなた坂46LIVEメンバー<br/>(12名)</button>
           <div className="category">期別</div>
           <button className='btn1' onClick={()=>onPlay({filters:[{key:"term",property:1}],category:"１期生メンバー"})}>１期生メンバー<br/>(11名)</button>
           <br />


### PR DESCRIPTION
問題選択画面の実装が、「ペンライト→メンバー四択QUIZ」と「メンバー→ペンライトカラーQUIZ」では共通化できていたものの、「ペンライトカラー一覧表示」だけ別になっていた。
この部分、DRYなコードに書き換えたいなー




いつの日か。